### PR TITLE
Fix BookRepository parsing and typo

### DIFF
--- a/Challenges/ThinkSharp.ByteBook/Models/Book.cs
+++ b/Challenges/ThinkSharp.ByteBook/Models/Book.cs
@@ -14,7 +14,7 @@ public class Book {
         }
 
         if (PageCount < 0) {
-            throw new ArgumentOutOfRangeException("PageCount must be non-nagative.");
+            throw new ArgumentOutOfRangeException("PageCount must be non-negative.");
         }
     }
 }

--- a/Challenges/ThinkSharp.ByteBook/Repository/BookRepository.cs
+++ b/Challenges/ThinkSharp.ByteBook/Repository/BookRepository.cs
@@ -59,13 +59,20 @@ public class BookRepository {
     public IEnumerable<Book> GetBooks() {
         var books = _source.Split("\n");
         foreach(var book in books) {
-            var newBook = book.Split(",");
+            if (string.IsNullOrWhiteSpace(book)) {
+                continue;
+            }
+
+            var newBook = book.Trim().Split(',');
+            if (newBook.Length < 4) {
+                continue;
+            }
 
             yield return new Book() {
-                Title = newBook[0],
-                Author = newBook[1],
-                PageCount = int.Parse(newBook[2]),
-                Category = Enum.Parse<Category>(newBook[3]),
+                Title = newBook[0].Trim(),
+                Author = newBook[1].Trim(),
+                PageCount = int.Parse(newBook[2].Trim()),
+                Category = Enum.Parse<Category>(newBook[3].Trim()),
             };
         }
     }


### PR DESCRIPTION
## Summary
- filter empty rows in `BookRepository.GetBooks()` to avoid runtime errors
- trim values and handle malformed rows
- fix typo in `Book.Validate`

## Testing
- `dotnet build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841c6628c28832cb4ab169eea4a70ca