### PR TITLE
Fix error message typo in ByteBook

### DIFF
--- a/Challenges/ThinkSharp.ByteBook/Models/Book.cs
+++ b/Challenges/ThinkSharp.ByteBook/Models/Book.cs
@@ -14,7 +14,7 @@ public class Book {
         }
 
         if (PageCount < 0) {
-            throw new ArgumentOutOfRangeException("PageCount must be non-negative.");
+            throw new ArgumentOutOfRangeException("PageCount must be non‑negative.");
         }
     }
 }


### PR DESCRIPTION
## Summary
- fix the typo in `Book.Validate` error message

## Testing
- `dotnet build ThinkSharp.sln -clp:ErrorsOnly` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841ca4d9940832cbdb948d9a9aad022