### PR TITLE
Fix enumerator dispose method

### DIFF
--- a/Challenges/ThinkSharp.HeroCollector/Avengers.cs
+++ b/Challenges/ThinkSharp.HeroCollector/Avengers.cs
@@ -51,11 +51,12 @@ public class Avengers : IEnumerator<string>
 
     public void Reset()
     {
+        _step = 0;
         Current = "";
     }
 
     public void Dispose()
     {
-        throw new NotImplementedException();
+        // nothing to clean up
     }
 }


### PR DESCRIPTION
## Summary
- clean up enumerator Dispose implementation so it no longer throws

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841cb4ae664832cb3bee520907e4a2b