### PR TITLE
Fix category label range

### DIFF
--- a/Challenges/ThinkSharp.ByteBook/Views/BookFormView.cs
+++ b/Challenges/ThinkSharp.ByteBook/Views/BookFormView.cs
@@ -9,7 +9,7 @@ public class BookFormView {
     public string LabelPageCount {get; private set; } = "Page Count: ";
     public int EntryPageCount {get; set; } = 0;
 
-    public string LabelCategory {get; private set; } = "Category (0 - 7): ";
+    public string LabelCategory {get; private set; } = "Category (0 - 8): ";
     public Category EntryCategory {get; set; } = 0;
     public BookFormView() {
         this.Load();


### PR DESCRIPTION
## Summary
- correct range displayed on the category prompt in BookFormView

## Testing
- `dotnet build Challenges/ThinkSharp.ByteBook/ThinkSharp.ByteBook.csproj -v minimal` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841cce02194832c87df78774f0a47d7